### PR TITLE
docs: document tagging/release process and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# CLAUDE.md
+
+Guidance for Claude Code and other contributors working in this repository.
+
+## Project
+
+`toscutil` is an R package providing utility functions (see [DESCRIPTION](DESCRIPTION)
+and [README.md](README.md)). Source lives in [R/](R), tests in
+[tests/testthat](tests/testthat), generated docs in [man/](man).
+
+## Contributing & workflow
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution workflow,
+including:
+
+- **Making edits** — the `devtools::document()` / `test()` / `check()` checks to
+  run after any change.
+- **Tagging and GitHub releases** — every `Version` bump in
+  [DESCRIPTION](DESCRIPTION) must be marked with an annotated `vX.Y.Z` git tag
+  and a GitHub release whose notes come from the matching [NEWS.md](NEWS.md)
+  section. This is manual; no GitHub Action creates tags or releases.
+- **Releasing to CRAN** — the final checks and submission steps.
+
+## Conventions
+
+- Bump the `Version` field in [DESCRIPTION](DESCRIPTION) and add a matching
+  `# toscutil vX.Y.Z` section to [NEWS.md](NEWS.md) for every user-facing change.
+- Keep generated `man/*.Rd` in sync by running `devtools::document()` after
+  changing roxygen comments in [R/](R).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,38 @@ pkgdown::build_site() # Build website in docs folder
 
 After doing these steps, you can push your changes to Github.
 
+# Tagging and GitHub Releases
+
+Every version bump (a change to the `Version` field in [DESCRIPTION](DESCRIPTION))
+should be marked with a git tag and an accompanying GitHub release. This is done
+manually after the version bump has been merged into `master` — there is **no**
+GitHub Action that creates tags or releases automatically (the workflows in
+[.github/workflows](.github/workflows) only run R CMD check, test coverage and
+pkgdown).
+
+For a version `X.Y.Z`:
+
+1.  Create an annotated tag on the `master` commit that bumped the version and
+    push it (omit the commit to tag the current `HEAD`):
+
+    ```sh
+    git tag -a vX.Y.Z <commit> -m "vX.Y.Z"
+    git push origin vX.Y.Z
+    ```
+
+2.  Create a GitHub release from that tag, using the version's section from
+    [NEWS.md](NEWS.md) as the release notes:
+
+    ```sh
+    gh release create vX.Y.Z --title "vX.Y.Z" --notes-file <news-section.md>
+    ```
+
+    The newest version (highest semantic version) is automatically marked as
+    "Latest".
+
+Tag and release names always use the `vX.Y.Z` form, matching the `Version` field
+in DESCRIPTION.
+
 # Releasing to CRAN
 
 Whenever a package maintainer wants to release a new version of the package to CRAN, they should:


### PR DESCRIPTION
Documents how versioning, git tags and GitHub releases work for this package, and adds a `CLAUDE.md` entry point.

## Changes

- **CONTRIBUTING.md**: new "Tagging and GitHub Releases" section describing the manual workflow — an annotated `vX.Y.Z` tag on the master commit that bumped the version, plus a GitHub release whose notes come from the matching `NEWS.md` section. Explicitly notes that **no** GitHub Action creates tags/releases automatically (the workflows only run R CMD check, test coverage and pkgdown).
- **CLAUDE.md** (new): contributor/agent entry point linking to CONTRIBUTING.md for the full workflow, plus the version/NEWS and `devtools::document()` conventions.

## Context

Done alongside backfilling the missing tags (v2.10.0–v2.13.0) and GitHub releases (v2.8.1–v2.13.0), so the documented process matches what now exists in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)